### PR TITLE
Remove the need for a password in noVNC

### DIFF
--- a/vnc_auto.html
+++ b/vnc_auto.html
@@ -104,7 +104,7 @@
             msg = '<form onsubmit="return setPassword();"';
             msg += '  style="margin-bottom: 0px">';
             msg += 'Password Required: ';
-            msg += '<input type=password size=10 id="password_input" class="noVNC_status">';
+            msg += '<input type=password size=10 value="robots1234" id="password_input" class="noVNC_status">';
             msg += '<\/form>';
             $D('noVNC_status_bar').setAttribute("class", "noVNC_status_warn");
             $D('noVNC_status').innerHTML = msg;
@@ -202,7 +202,8 @@
                 }
             }
 
-            password = WebUtil.getConfigVar('password', '');
+            // password = WebUtil.getConfigVar('password', '');
+            password = "robots1234"
             path = WebUtil.getConfigVar('path', 'websockify');
 
             // If a token variable is passed in, set the parameter in a cookie.


### PR DESCRIPTION
For this to become active in RfR or Cinch, this file has to be copied in /usr/local/share/noVNC/index.html
(this is done when we do a Jessie update from scratch, but I don't think it's done on a DI Update)

This only removes the need to manually enter a password for noVNC